### PR TITLE
Handle window.ai.[assistant|languageModel]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "main"
+    ]
+}

--- a/script.js
+++ b/script.js
@@ -27,9 +27,10 @@ import DOMPurify from "https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.
 
   responseArea.style.display = "none";
 
+  let sessionFactory = window.ai.assistant ? window.ai.assistant : window.ai.languageModel;
   let session = null;
 
-  if (!window.ai || !window.ai.assistant) {
+  if (!window.ai || !sessionFactory) {
     errorMessage.style.display = "block";
     errorMessage.innerHTML = `Your browser doesn't support the Prompt API. If you're on Chrome, join the <a href="https://developer.chrome.com/docs/ai/built-in#get_an_early_preview">Early Preview Program</a> to enable it.`;
     return;
@@ -171,7 +172,7 @@ import DOMPurify from "https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.
   });
 
   const updateSession = async () => {
-    session = await window.ai.assistant.create({
+    session = await sessionFactory.create({
       temperature: Number(sessionTemperature.value),
       topK: Number(sessionTopK.value),
     });
@@ -189,7 +190,7 @@ import DOMPurify from "https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.
 
   if (!session) {
     const { defaultTopK, maxTopK, defaultTemperature } =
-      await window.ai.assistant.capabilities();
+      await sessionFactory.capabilities();
     sessionTemperature.value = defaultTemperature;
     sessionTopK.value = defaultTopK;
     sessionTopK.max = maxTopK;

--- a/script.js
+++ b/script.js
@@ -27,7 +27,7 @@ import DOMPurify from "https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.
 
   responseArea.style.display = "none";
 
-  let sessionFactory = window.ai.assistant ? window.ai.assistant : window.ai.languageModel;
+  let sessionFactory = window.ai?.assistant ? window.ai.assistant : window.ai?.languageModel;
   let session = null;
 
   if (!window.ai || !sessionFactory) {


### PR DESCRIPTION
Hey @tomayac, this PR fixies Chrome Canary 131.0.6776.0's use of `window.ai.languageModel` instead of `window.ai.assistant`.
I verified that this WAI on my [fork](https://michaelwasserman.github.io/prompt-api-playground/). Please take a look, thanks!